### PR TITLE
Remove Groestl support

### DIFF
--- a/keyconv.c
+++ b/keyconv.c
@@ -22,7 +22,6 @@ char ticker[10];
 
 const char *version = VANITYGEN_VERSION;
 
-int GRSFlag = 0;
 int TRXFlag = 0;
 
 static void
@@ -107,11 +106,9 @@ main(int argc, char **argv)
 				if (vg_get_altcoin(optarg, &addrtype_opt, &privtype_opt, NULL)) {
 					return 1;
 				}
-				if (strcmp(optarg, "GRS")== 0) {
-					GRSFlag = 1;
-				} else if (strcmp(optarg, "TRX")== 0) {
-					TRXFlag = 1;
-				}
+                                if (strcmp(optarg, "TRX")== 0) {
+                                        TRXFlag = 1;
+                                }
 			}
 			break;
 

--- a/oclvanitygen.c
+++ b/oclvanitygen.c
@@ -32,7 +32,6 @@
 #include "ticker.h"
 char ticker[10];
 
-int GRSFlag = 0;
 int TRXFlag = 0;
 
 const char *version = VANITYGEN_VERSION;
@@ -216,9 +215,7 @@ main(int argc, char **argv)
                 if (vg_get_altcoin(optarg, &addrtype, &privtype, NULL)) {
                     return 1;
                 }
-                if (strcmp(optarg, "GRS")== 0) {
-                    GRSFlag = 1;
-                } else if (strcmp(optarg, "TRX")== 0) {
+                if (strcmp(optarg, "TRX")== 0) {
                     TRXFlag = 1;
                 }
             }

--- a/oclvanityminer.c
+++ b/oclvanityminer.c
@@ -40,7 +40,6 @@ char ticker[10];
 char workurl[2048];
 int workurlFlag = 0;
 
-int GRSFlag = 0;
 int TRXFlag = 0;
 
 const char *version = VANITYGEN_VERSION;

--- a/util.c
+++ b/util.c
@@ -39,7 +39,6 @@
 
 #include "pattern.h"
 #include "util.h"
-#include "sph_groestl.h"
 #include "sha3.h"
 #include "ticker.h"
 
@@ -106,8 +105,6 @@ vg_b58_encode_check(void *buf, size_t len, char *result)
 {
 	unsigned char hash1[32];
 	unsigned char hash2[32];
-	unsigned char groestlhash1[64];
-	unsigned char groestlhash2[64];
 
 	int d, p;
 
@@ -131,25 +128,9 @@ vg_b58_encode_check(void *buf, size_t len, char *result)
 	binres = (unsigned char*) malloc(brlen);
 	memcpy(binres, buf, len);
 
-	if(!GRSFlag)
-	{
-		SHA256(binres, len, hash1);
-		SHA256(hash1, sizeof(hash1), hash2);
-		memcpy(&binres[len], hash2, 4);
-	}
-	else
-	{
-		sph_groestl512_context ctx;
-		
-		sph_groestl512_init(&ctx);
-		sph_groestl512(&ctx, binres, len);
-		sph_groestl512_close(&ctx, groestlhash1);
-		
-		sph_groestl512_init(&ctx);
-		sph_groestl512(&ctx, groestlhash1, sizeof(groestlhash1));
-		sph_groestl512_close(&ctx, groestlhash2);
-		memcpy(&binres[len], groestlhash2, 4);
-	}
+        SHA256(binres, len, hash1);
+        SHA256(hash1, sizeof(hash1), hash2);
+        memcpy(&binres[len], hash2, 4);
 
 	BN_bin2bn(binres, len + 4, bn);
 
@@ -191,8 +172,6 @@ vg_b58_decode_check(const char *input, void *buf, size_t len)
 	BIGNUM *bn, *bnw, *bnbase;
 	BN_CTX *bnctx;
 	unsigned char hash1[32], hash2[32];
-	unsigned char groestlhash1[64];
-	unsigned char groestlhash2[64];
 	int zpfx;
 	int res = 0;
 
@@ -239,28 +218,10 @@ vg_b58_decode_check(const char *input, void *buf, size_t len)
 	/* Check the hash code */
 	l -= 4;
 
-	if(!GRSFlag)
-	{
-		SHA256(xbuf, l, hash1);
-		SHA256(hash1, sizeof(hash1), hash2);
-		if (memcmp(hash2, xbuf + l, 4))
-			goto out;
-	}
-	else
-	{
-		sph_groestl512_context ctx;
-		
-		sph_groestl512_init(&ctx);
-		sph_groestl512(&ctx, xbuf, l);
-		sph_groestl512_close(&ctx, groestlhash1);
-		
-		sph_groestl512_init(&ctx);
-		sph_groestl512(&ctx, groestlhash1, sizeof(groestlhash1));
-		sph_groestl512_close(&ctx, groestlhash2);
-
-		if (memcmp(groestlhash2, xbuf + l, 4))
-			goto out;
-	}
+        SHA256(xbuf, l, hash1);
+        SHA256(hash1, sizeof(hash1), hash2);
+        if (memcmp(hash2, xbuf + l, 4))
+                goto out;
 
 	/* Buffer verified */
 	if (len) {

--- a/util.h
+++ b/util.h
@@ -25,7 +25,6 @@
 #include <openssl/bn.h>
 #include <openssl/ec.h>
 
-extern int GRSFlag;
 extern int TRXFlag;
 
 extern const char *vg_b58_alphabet;

--- a/vanitygen.c
+++ b/vanitygen.c
@@ -36,7 +36,6 @@
 #include "ticker.h"
 char ticker[10];
 
-int GRSFlag = 0;
 int TRXFlag = 0;
 
 const char *version = VANITYGEN_VERSION;
@@ -474,11 +473,9 @@ main(int argc, char **argv)
 				if (vg_get_altcoin(optarg, &addrtype, &privtype, &bech32_hrp)) {
 					return 1;
 				}
-                if (strcmp(optarg, "GRS")== 0) {
-                    GRSFlag = 1;
-                } else if (strcmp(optarg, "TRX") == 0) {
-					TRXFlag = 1;
-				}
+                if (strcmp(optarg, "TRX") == 0) {
+                    TRXFlag = 1;
+                }
 			}
 			break;
 


### PR DESCRIPTION
## Summary
- drop groestl hash code paths and header include
- remove all uses of `GRSFlag`
- keep ETH/TRX logic only

## Testing
- `make all` *(fails: pcre.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68629142a3c8832fa6d9562a9ffcfedf