### PR TITLE
Add TRX address tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,13 @@ oclvanityminer: oclvanityminer.o oclengine.o pattern.o util.o sha3.o
 keyconv: keyconv.o util.o sha3.o
 	$(CC) $^ -o $@ $(CFLAGS) $(LIBS)
 
-test:
-	@echo "No tests available"
+TESTS=tests/test_trx
+
+$(TESTS): tests/test_trx.c util.o sha3.o
+	$(CC) tests/test_trx.c util.o sha3.o -I. $(CFLAGS) -lcrypto -lm -lpthread -o $@
+
+test: $(TESTS)
+	./$<
 
 clean:
 	rm -f $(OBJS) $(PROGS) $(TESTS) *.oclbin

--- a/sph_groestl.h
+++ b/sph_groestl.h
@@ -1,0 +1,8 @@
+#ifndef SPH_GROESTL_H
+#define SPH_GROESTL_H
+#include <stddef.h>
+typedef struct { unsigned char dummy; } sph_groestl512_context;
+static inline void sph_groestl512_init(sph_groestl512_context *ctx) {(void)ctx;}
+static inline void sph_groestl512(sph_groestl512_context *ctx, const void *data, size_t len) {(void)ctx;(void)data;(void)len;}
+static inline void sph_groestl512_close(sph_groestl512_context *ctx, void *dst) {(void)ctx;(void)dst;}
+#endif

--- a/tests/test_trx.c
+++ b/tests/test_trx.c
@@ -1,0 +1,50 @@
+#include <assert.h>
+#include <openssl/ec.h>
+#include <openssl/obj_mac.h>
+#include <string.h>
+#include "util.h"
+#include "sha3.h"
+#include "ticker.h"
+
+int TRXFlag = 0;
+int GRSFlag = 0;
+char ticker[10];
+
+static void test_trx_encode_decode(void)
+{
+    EC_KEY *key = EC_KEY_new_by_curve_name(NID_secp256k1);
+    assert(key != NULL);
+    assert(EC_KEY_generate_key(key) == 1);
+
+    const EC_GROUP *group = EC_KEY_get0_group(key);
+    const EC_POINT *pub = EC_KEY_get0_public_key(key);
+
+    TRXFlag = 1;
+    strcpy(ticker, "TRX");
+    char addr[64];
+    vg_encode_address(pub, group, 65, 0, addr);
+
+    unsigned char bin[21];
+    int res = vg_b58_decode_check(addr, bin, sizeof(bin));
+    assert(res == 21);
+    assert(bin[0] == 65);
+
+    unsigned char pubbuf[65];
+    unsigned char hash[32];
+    EC_POINT_point2oct(group, pub, POINT_CONVERSION_UNCOMPRESSED,
+                       pubbuf, sizeof(pubbuf), NULL);
+    SHA3_256(hash, pubbuf + 1, 64);
+
+    unsigned char expected[21];
+    expected[0] = 65;
+    memcpy(expected + 1, hash + 12, 20);
+    assert(memcmp(bin, expected, 21) == 0);
+
+    EC_KEY_free(key);
+}
+
+int main(void)
+{
+    test_trx_encode_decode();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a stub `sph_groestl.h` to build without groestl sources
- implement a minimal TRX address encode/decode unit test
- update `Makefile` to build and run the test via `make test`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686291430b80832fb1d0ea5bd2e19528